### PR TITLE
Fixes several knapping exploits via Hotbar 1-9 HotKeys

### DIFF
--- a/src/Common/com/bioxx/tfc2/containers/ContainerSpecialCrafting.java
+++ b/src/Common/com/bioxx/tfc2/containers/ContainerSpecialCrafting.java
@@ -127,25 +127,31 @@ public class ContainerSpecialCrafting extends ContainerTFC
 	public ItemStack transferStackInSlotTFC(EntityPlayer player, int slotNum)
 	{
 		Slot slot = (Slot)this.inventorySlots.get(slotNum);
-		if (slot == null)  return ItemStack.EMPTY;
+		if (slot == null || !slot.getHasStack())  return ItemStack.EMPTY;
 		ItemStack origStack = slot.getStack();
+		ItemStack slotStack = origStack.copy(); 
+		InventoryPlayer ip = player.inventory;
 
-		if (slot instanceof SlotSpecialCraftingOutput && slot.getHasStack())
+		// From Crafting Grid Output to inventory
+		if (slot instanceof SlotSpecialCraftingOutput)
 		{
-			ItemStack slotStack = slot.getStack();
-			InventoryPlayer ip = player.inventory;
-
 			if (slotNum < 1 && !ip.addItemStackToInventory(slotStack))
 				return ItemStack.EMPTY;
-
-			if (slotStack.getMaxStackSize() <= 0)
-				slot.putStack(ItemStack.EMPTY);
-			else
-				slot.onSlotChanged();
-
-			slot.onTake(player, slotStack);
 		}
+		// From inventory to Hotbar
+		else if (slotNum >= 1 && slotNum < 28 && !this.mergeItemStack(slotStack, 28, 37, false))
+			return ItemStack.EMPTY;
+		// From Hotbar to inventory
+		else if (slotNum >= 28 && slotNum < 37 && !this.mergeItemStack(slotStack, 1, 28, false))
+			return ItemStack.EMPTY;
 
+		if (slotStack.getMaxStackSize() <= 0)
+			slot.putStack(ItemStack.EMPTY);
+		else
+			slot.onSlotChanged();
+
+		slot.onTake(player, slotStack);
+		
 		return origStack;
 	}
 	

--- a/src/Common/com/bioxx/tfc2/containers/ContainerSpecialCrafting.java
+++ b/src/Common/com/bioxx/tfc2/containers/ContainerSpecialCrafting.java
@@ -166,7 +166,6 @@ public class ContainerSpecialCrafting extends ContainerTFC
 	 */
 	public ItemStack slotClick(int slotID, int dragType, ClickType clickTypeIn, EntityPlayer player)
 	{
-		//System.out.println("*** CSC slotClick: "+slotID+" , "+dragType+" , "+clickTypeIn);  //Debug
 		if (slotID == 28 + invPlayer.currentItem || clickTypeIn == ClickType.SWAP && dragType == invPlayer.currentItem)
 			return ItemStack.EMPTY;
 		if (slotID == 0 && clickTypeIn == ClickType.SWAP && dragType >= 0 && dragType < 9)
@@ -211,6 +210,20 @@ public class ContainerSpecialCrafting extends ContainerTFC
 	{
 		return true;
 	}
+
+	@Override
+	public boolean canMergeSlot(ItemStack stack, Slot slotIn)
+    {
+        if (slotIn.getSlotIndex() == invPlayer.currentItem)  return false;
+        else  return  super.canMergeSlot(stack, slotIn);
+    }
+	
+	@Override
+    public boolean canDragIntoSlot(Slot slotIn)
+    {
+        if (slotIn.getSlotIndex() == invPlayer.currentItem)  return false;
+        else  return super.canDragIntoSlot(slotIn);
+    }
 
 	public boolean hasPieceBeenRemoved(PlayerInfo pi)
 	{

--- a/src/Common/com/bioxx/tfc2/containers/ContainerSpecialCrafting.java
+++ b/src/Common/com/bioxx/tfc2/containers/ContainerSpecialCrafting.java
@@ -166,8 +166,12 @@ public class ContainerSpecialCrafting extends ContainerTFC
 	 */
 	public ItemStack slotClick(int slotID, int dragType, ClickType clickTypeIn, EntityPlayer player)
 	{
+		// 1. Freeze current slot (Main Hand held item)
 		if (slotID == 28 + invPlayer.currentItem || clickTypeIn == ClickType.SWAP && dragType == invPlayer.currentItem)
 			return ItemStack.EMPTY;
+		// 2. Take items from crafting output slot & put them into HotBar slot 1-9. 
+		//    - Works better than vanilla: merges crafted items with identical items in HotBar slot.
+		//    - Correctly handles multiple items (in case knapping will ever output more than 1 item per stack).
 		if (slotID == 0 && clickTypeIn == ClickType.SWAP && dragType >= 0 && dragType < 9)
 		{
 			Slot sourceSlot = (Slot) this.inventorySlots.get(slotID);
@@ -189,11 +193,11 @@ public class ContainerSpecialCrafting extends ContainerTFC
 				{
 					int sCnt = sourceStack.getCount(); 
 					int tCnt = targetStack.getCount();
-					int n = Math.min(targetStack.getMaxStackSize() - tCnt, sCnt);
-					if (n <= 0)  return ItemStack.EMPTY;
-					sourceStack.splitStack(n);
-					targetStack.setCount(tCnt + n);
-					if (n < sCnt)  return ItemStack.EMPTY;
+					int xferCnt = Math.min(targetStack.getMaxStackSize() - tCnt, sCnt);
+					if (xferCnt <= 0)  return ItemStack.EMPTY;
+					sourceStack.splitStack(xferCnt);
+					targetStack.setCount(tCnt + xferCnt);
+					if (xferCnt < sCnt)  return ItemStack.EMPTY;
 				}
 				sourceSlot.onSlotChanged();
 				sourceSlot.onTake(player, sourceStack);
@@ -211,6 +215,7 @@ public class ContainerSpecialCrafting extends ContainerTFC
 		return true;
 	}
 
+	// Freeze current slot - disable double-click merging 
 	@Override
 	public boolean canMergeSlot(ItemStack stack, Slot slotIn)
 	{
@@ -218,6 +223,7 @@ public class ContainerSpecialCrafting extends ContainerTFC
 		else  return super.canMergeSlot(stack, slotIn);
 	}
 	
+	// Freeze current slot - disable dragging  
 	@Override
 	public boolean canDragIntoSlot(Slot slotIn)
 	{

--- a/src/Common/com/bioxx/tfc2/containers/ContainerSpecialCrafting.java
+++ b/src/Common/com/bioxx/tfc2/containers/ContainerSpecialCrafting.java
@@ -128,14 +128,14 @@ public class ContainerSpecialCrafting extends ContainerTFC
 	{
 		Slot slot = (Slot)this.inventorySlots.get(slotNum);
 		if (slot == null || !slot.getHasStack())  return ItemStack.EMPTY;
-		ItemStack origStack = slot.getStack();
-		ItemStack slotStack = origStack.copy(); 
+		ItemStack slotStack = slot.getStack();
+		ItemStack origStack = slotStack.copy(); 
 		InventoryPlayer ip = player.inventory;
 
 		// From Crafting Grid Output to inventory
 		if (slot instanceof SlotSpecialCraftingOutput)
 		{
-			if (slotNum < 1 && !ip.addItemStackToInventory(slotStack))
+			if (slotNum == 0 && !ip.addItemStackToInventory(slotStack))
 				return ItemStack.EMPTY;
 		}
 		// From inventory to Hotbar
@@ -145,13 +145,18 @@ public class ContainerSpecialCrafting extends ContainerTFC
 		else if (slotNum >= 28 && slotNum < 37 && !this.mergeItemStack(slotStack, 1, 28, false))
 			return ItemStack.EMPTY;
 
-		if (slotStack.getMaxStackSize() <= 0)
+		if (slotStack.isEmpty())
 			slot.putStack(ItemStack.EMPTY);
 		else
 			slot.onSlotChanged();
 
-		slot.onTake(player, slotStack);
-		
+		if (slotStack.getCount() == origStack.getCount())
+			return ItemStack.EMPTY;
+
+		ItemStack itemstack2 = slot.onTake(player, slotStack);
+		if (slotNum == 0)
+			player.dropItem(itemstack2, false);
+
 		return origStack;
 	}
 	
@@ -167,9 +172,11 @@ public class ContainerSpecialCrafting extends ContainerTFC
 		if (slotID == 0 && clickTypeIn == ClickType.SWAP && dragType >= 0 && dragType < 9)
 		{
 			Slot sourceSlot = (Slot) this.inventorySlots.get(slotID);
+			if (sourceSlot == null)  return ItemStack.EMPTY;
 			ItemStack sourceStack = sourceSlot.getStack();
 			if (sourceStack == null || sourceStack.isEmpty())  return ItemStack.EMPTY;
 			Slot targetSlot = (Slot) this.inventorySlots.get(28 + dragType);
+			if (targetSlot == null)  return ItemStack.EMPTY;
 			ItemStack targetStack = targetSlot.getStack();
 			
 			if (canAddItemToSlot(targetSlot, sourceStack, true)) 
@@ -191,7 +198,7 @@ public class ContainerSpecialCrafting extends ContainerTFC
 				}
 				sourceSlot.onSlotChanged();
 				sourceSlot.onTake(player, sourceStack);
-				return invPlayer.getStackInSlot(dragType);
+				return ItemStack.EMPTY;
 			}
 			else
 				return ItemStack.EMPTY;

--- a/src/Common/com/bioxx/tfc2/containers/ContainerSpecialCrafting.java
+++ b/src/Common/com/bioxx/tfc2/containers/ContainerSpecialCrafting.java
@@ -213,17 +213,17 @@ public class ContainerSpecialCrafting extends ContainerTFC
 
 	@Override
 	public boolean canMergeSlot(ItemStack stack, Slot slotIn)
-    {
-        if (slotIn.getSlotIndex() == invPlayer.currentItem)  return false;
-        else  return  super.canMergeSlot(stack, slotIn);
-    }
+	{
+		if (slotIn.getSlotIndex() == invPlayer.currentItem)  return false;
+		else  return super.canMergeSlot(stack, slotIn);
+	}
 	
 	@Override
-    public boolean canDragIntoSlot(Slot slotIn)
-    {
-        if (slotIn.getSlotIndex() == invPlayer.currentItem)  return false;
-        else  return super.canDragIntoSlot(slotIn);
-    }
+	public boolean canDragIntoSlot(Slot slotIn)
+	{
+		if (slotIn.getSlotIndex() == invPlayer.currentItem)  return false;
+		else  return super.canDragIntoSlot(slotIn);
+	}
 
 	public boolean hasPieceBeenRemoved(PlayerInfo pi)
 	{

--- a/src/Common/com/bioxx/tfc2/containers/slots/SlotForShowOnly.java
+++ b/src/Common/com/bioxx/tfc2/containers/slots/SlotForShowOnly.java
@@ -23,4 +23,15 @@ public class SlotForShowOnly extends Slot
 	{
 		return false;
 	}
+
+	@Override
+	public int getSlotStackLimit()
+	{
+		return 0;
+	}
+	@Override
+	public int getItemStackLimit(ItemStack stack)
+	{
+		return 0;
+	}
 }

--- a/src/Common/com/bioxx/tfc2/gui/GuiKnapping.java
+++ b/src/Common/com/bioxx/tfc2/gui/GuiKnapping.java
@@ -191,6 +191,11 @@ public class GuiKnapping extends GuiContainerTFC
 	@Override
 	protected void mouseClickMove(int mouseX, int mouseY, int clickedMouseButton, long timeSinceLastClick) 
 	{
+		if (mouseY > 88+guiTop || mouseX > 88+guiLeft || mouseY < 16+guiTop || mouseX < 16+guiLeft)
+		{
+			super.mouseClickMove(mouseX, mouseY, clickedMouseButton, timeSinceLastClick);
+			return;
+		}
 		if (clickedMouseButton == 0)
 		{
 			for (int l = 0; l < this.buttonList.size(); ++l)
@@ -218,5 +223,7 @@ public class GuiKnapping extends GuiContainerTFC
 				}
 			}
 		}
+		else
+			super.mouseClickMove(mouseX, mouseY, clickedMouseButton, timeSinceLastClick);
 	}
 }

--- a/src/Common/com/bioxx/tfc2/gui/GuiKnapping.java
+++ b/src/Common/com/bioxx/tfc2/gui/GuiKnapping.java
@@ -191,6 +191,8 @@ public class GuiKnapping extends GuiContainerTFC
 	@Override
 	protected void mouseClickMove(int mouseX, int mouseY, int clickedMouseButton, long timeSinceLastClick) 
 	{
+		// 1-st Check if the click falls inside the Knapping Grid boundaries. 
+		// (Doing so reduces the lag & allows for super methods to run when inventory slots are clicked.)
 		if (mouseY > 88+guiTop || mouseX > 88+guiLeft || mouseY < 16+guiTop || mouseX < 16+guiLeft)
 		{
 			super.mouseClickMove(mouseX, mouseY, clickedMouseButton, timeSinceLastClick);


### PR DESCRIPTION
Example exploit:  With knapping GUI open hover over the current hotbar item (the rocks you are using) & hit a 1-9 HotKey for another hotbar slot. This allows to remove the whole stack from the current hotbar slot & to knap for free.